### PR TITLE
Update NewSiteViewModel.cs

### DIFF
--- a/src/cloudscribe.Core.Web/ViewModels/SiteSettings/NewSiteViewModel.cs
+++ b/src/cloudscribe.Core.Web/ViewModels/SiteSettings/NewSiteViewModel.cs
@@ -36,7 +36,7 @@ namespace cloudscribe.Core.Web.ViewModels.SiteSettings
         [Remote("AliasIdAvailable", "SiteAdmin", AdditionalFields = "SiteId",
            ErrorMessage = "AliasId not available, please try another value",
            HttpMethod = "Post")]
-        [RegularExpression(@"^[a-zA-Z0-9_-]+$", ErrorMessage = "only digits, numbers, - and _ allowed, no spaces allowed")]
+        [RegularExpression(@"^[a-zA-Z0-9_\-]+$", ErrorMessage = "only digits, numbers, - and _ allowed, no spaces allowed")]
         [StringLength(36, ErrorMessage = "AliasId has a maximum length of 36 characters")]
         public string AliasId { get; set; } = string.Empty;
 
@@ -48,14 +48,14 @@ namespace cloudscribe.Core.Web.ViewModels.SiteSettings
         [Remote("FolderNameAvailable", "SiteAdmin", AdditionalFields = "SiteId",
            ErrorMessage = "Requested Site Folder Name is not available, please try another value",
            HttpMethod = "Post")]
-        [RegularExpression(@"^[a-zA-Z0-9_-]+$", ErrorMessage = "For Site Folder Name, only digits, numbers, - and _ allowed, no spaces allowed")]
+        [RegularExpression(@"^[a-zA-Z0-9_\-]+$", ErrorMessage = "For Site Folder Name, only digits, numbers, - and _ allowed, no spaces allowed")]
         [StringLength(50, ErrorMessage = "Site Folder name has a maximum length of 50 characters")]
         public string SiteFolderName { get; set; } = string.Empty;
 
         [Remote("HostNameAvailable", "SiteAdmin", AdditionalFields = "SiteId",
            ErrorMessage = "Requested Host name is not available",
            HttpMethod = "Post")]
-        [RegularExpression(@"^[a-zA-Z0-9_-]+$", ErrorMessage = "For Host name, only digits, numbers, - and _ allowed, no spaces allowed")]
+        [RegularExpression(@"^[a-zA-Z0-9_\-.]+$", ErrorMessage = "For Host name, only digits, numbers, periods(.), - and _ allowed, no spaces allowed")]
         [StringLength(255, ErrorMessage = "Host name has a maximum length of 255 characters")]
         public string HostName { get; set; } = string.Empty;
         


### PR DESCRIPTION
In a Cloudscribe project using host names, the following validation error shows up in New Site and Site Info screens:
For Host name, only digits, numbers, - and _ allowed, no spaces allowed
so it will not let you enter something like: www.mydomain.com
I added the delimiter before the hyphen in the regular expression for folder names and host names. I added the period character as an allowed character in the regular expression for host name and added period to the descriptive error.