### PR TITLE
Update SiteManager.cs

### DIFF
--- a/src/cloudscribe.Core.Web/Components/SiteManager.cs
+++ b/src/cloudscribe.Core.Web/Components/SiteManager.cs
@@ -198,8 +198,15 @@ namespace cloudscribe.Core.Web.Components
             }
             else
             {
-                if(_context != null && !string.IsNullOrEmpty(_context.Request.Host.Value))
-                _cacheHelper.ClearCache(_context.Request.Host.Value);
+                _cacheHelper.ClearCache(site.PreferredHostName);
+                var siteHosts = await GetSiteHosts(site.Id);
+                if (siteHosts != null && siteHosts.Count > 0)
+                {
+                    foreach(ISiteHost siteHostName in siteHosts)
+                    {
+                        _cacheHelper.ClearCache(siteHostName.HostName);
+                    }
+                }
             }
             _cacheHelper.ClearCache("site-" + site.Id.ToString());
 


### PR DESCRIPTION
In an implementation using domain based tenants, if the site admin went in and made a change to a tenant's setting (such as changing the theme or site name), if a user was on the tenant site, they would not see the changes made because the old settings were "stuck" in cache. The original implementation in the SiteManager Update function was getting the host name from the current request context rather than the from that of the passed in site ID. Also, the change accommodates the scenario where the tenant site has additional host mappings. I believe there would be an entry in cache with a key name based on the additional host name.