### PR TITLE
Improve formatting of confirmation email for new users

### DIFF
--- a/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/Shared/EmailTemplates/ConfirmAccountHtmlEmail.cshtml
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/Shared/EmailTemplates/ConfirmAccountHtmlEmail.cshtml
@@ -6,10 +6,14 @@
     ViewData["Site"] = Model.Tenant;
 }
 <p>
-    Please confirm your account by clicking this link: <a href="@Model.ConfirmationUrl">link</a>
+    Please confirm your account by clicking this <a href="@Model.ConfirmationUrl">link</a>.
 </p>
 <p>
-    Or submit this codeon the website form.
+    Or submit this code on the website form.
 </p>
-<textarea id="confirmcode" rows="5" cols="55">@Model.ConfirmationCode</textarea>
 
+<table border="0" cellspacing="0" cellpadding="5">
+<tr>
+    <td style="word-break:break-all; border:1px solid black; width:500px;">@Model.ConfirmationCode</td>
+</tr>
+</table>

--- a/src/cloudscribe.Core.CompiledViews.Bootstrap4/cloudscribe.Core.CompiledViews.Bootstrap4.csproj
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap4/cloudscribe.Core.CompiledViews.Bootstrap4.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Bootstrap 4 pre-compiled views for cloudscribe.Core.Web</Description>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>


### PR DESCRIPTION
Outlook and maybe some other email clients cannot display a textarea HTML tag. Moving the confirmation code into a table cell with wrapping enabled. #691