### PR TITLE
Issue647

### DIFF
--- a/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/Shared/EmailTemplates/NewAccountAdminNotificationHtmlEmail.cshtml
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/Shared/EmailTemplates/NewAccountAdminNotificationHtmlEmail.cshtml
@@ -1,0 +1,8 @@
+@model cloudscribe.Core.Web.ViewModels.Email.NewAccountEmailViewModel
+
+@{
+    Layout = "_LayoutEmailNotification";
+    ViewData["Title"] = "New User Account";
+    ViewData["Site"] = Model.Tenant;
+}
+A new user just registered at @Model.Tenant.SiteName with email address @Model.User.Email

--- a/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/Shared/EmailTemplates/NewAccountAdminNotificationTextEmail.cshtml
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/Shared/EmailTemplates/NewAccountAdminNotificationTextEmail.cshtml
@@ -1,0 +1,8 @@
+@model cloudscribe.Core.Web.ViewModels.Email.NewAccountEmailViewModel
+
+@{
+    Layout = "_LayoutEmailNotification";
+    ViewData["Title"] = "New User Account";
+    ViewData["Site"] = Model.Tenant;
+}
+A new user just registered at @Model.Tenant.SiteName with email address @Model.User.Email

--- a/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/SiteAdmin/SecuritySettings.cshtml
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/SiteAdmin/SecuritySettings.cshtml
@@ -50,7 +50,7 @@
         </div>
     </div>
     <div class="form-group">
-        <label asp-for="AccountApprovalEmailCsv">@sr["Email addresses (csv) to notify of new users and new unapproved users"]</label>
+        <label asp-for="AccountApprovalEmailCsv">@sr["Email addresses (csv) to notify of new users"]</label>
         <input asp-for="AccountApprovalEmailCsv" class="form-control" />
         <span asp-validation-for="AccountApprovalEmailCsv" class="invalid-feedback"></span>
     </div>

--- a/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/SiteAdmin/SecuritySettings.cshtml
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap4/Views/SiteAdmin/SecuritySettings.cshtml
@@ -50,7 +50,7 @@
         </div>
     </div>
     <div class="form-group">
-        <label asp-for="AccountApprovalEmailCsv">@sr["Email addresses (csv) to notify of new unapproved users"]</label>
+        <label asp-for="AccountApprovalEmailCsv">@sr["Email addresses (csv) to notify of new users and new unapproved users"]</label>
         <input asp-for="AccountApprovalEmailCsv" class="form-control" />
         <span asp-validation-for="AccountApprovalEmailCsv" class="invalid-feedback"></span>
     </div>

--- a/src/cloudscribe.Core.CompiledViews.Bootstrap4/cloudscribe.Core.CompiledViews.Bootstrap4.csproj
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap4/cloudscribe.Core.CompiledViews.Bootstrap4.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Bootstrap 4 pre-compiled views for cloudscribe.Core.Web</Description>
-    <Version>4.0.4</Version>
+    <Version>4.0.5</Version>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>

--- a/src/cloudscribe.Core.Web/Components/AccountService.cs
+++ b/src/cloudscribe.Core.Web/Components/AccountService.cs
@@ -667,6 +667,21 @@ namespace cloudscribe.Core.Web.Components
             return new VerifyEmailResult(userContext, result);
         }
 
+        public virtual async Task<bool?> IsEmailConfirmedAsync(string userId, string code)
+        {
+            IUserContext userContext = null;
+            IdentityResult result = IdentityResult.Failed(null);
+
+            var user = await UserManager.FindByIdAsync(userId);
+            if(user != null)
+            {
+                userContext = new UserContext(user);
+                return userContext.EmailConfirmed;
+            }
+            //return bool? null if not a valid user
+            return null;
+        }
+
         public virtual async Task<IUserContext> GetTwoFactorAuthenticationUserAsync()
         {
             var user = await SignInManager.GetTwoFactorAuthenticationUserAsync();

--- a/src/cloudscribe.Core.Web/Components/AccountService.cs
+++ b/src/cloudscribe.Core.Web/Components/AccountService.cs
@@ -667,7 +667,7 @@ namespace cloudscribe.Core.Web.Components
             return new VerifyEmailResult(userContext, result);
         }
 
-        public virtual async Task<bool?> IsEmailConfirmedAsync(string userId, string code)
+        public virtual async Task<bool?> IsEmailConfirmedAsync(string userId)
         {
             IUserContext userContext = null;
             IdentityResult result = IdentityResult.Failed(null);

--- a/src/cloudscribe.Core.Web/Components/IAccountService.cs
+++ b/src/cloudscribe.Core.Web/Components/IAccountService.cs
@@ -19,7 +19,7 @@ namespace cloudscribe.Core.Web.Components
         Task<bool> AcceptRegistrationAgreement(ClaimsPrincipal principal);
         AuthenticationProperties ConfigureExternalAuthenticationProperties(string provider, string returnUrl = null);
         Task<VerifyEmailResult> ConfirmEmailAsync(string userId, string code);
-        Task<bool?> IsEmailConfirmedAsync(string userId, string code);
+        Task<bool?> IsEmailConfirmedAsync(string userId);
         Task<VerifyEmailInfo> GetEmailVerificationInfo(Guid userId);
         Task<List<AuthenticationScheme>> GetExternalAuthenticationSchemes();
         Task<ResetPasswordInfo> GetPasswordResetInfo(string email);

--- a/src/cloudscribe.Core.Web/Components/IAccountService.cs
+++ b/src/cloudscribe.Core.Web/Components/IAccountService.cs
@@ -19,6 +19,7 @@ namespace cloudscribe.Core.Web.Components
         Task<bool> AcceptRegistrationAgreement(ClaimsPrincipal principal);
         AuthenticationProperties ConfigureExternalAuthenticationProperties(string provider, string returnUrl = null);
         Task<VerifyEmailResult> ConfirmEmailAsync(string userId, string code);
+        Task<bool?> IsEmailConfirmedAsync(string userId, string code);
         Task<VerifyEmailInfo> GetEmailVerificationInfo(Guid userId);
         Task<List<AuthenticationScheme>> GetExternalAuthenticationSchemes();
         Task<ResetPasswordInfo> GetPasswordResetInfo(string email);

--- a/src/cloudscribe.Core.Web/Components/Messaging/FakeSiteEmailSender.cs
+++ b/src/cloudscribe.Core.Web/Components/Messaging/FakeSiteEmailSender.cs
@@ -44,6 +44,13 @@ namespace cloudscribe.Core.Web.Components.Messaging
             return Task.CompletedTask;
         }
 
+        public Task NewAccountAdminNotification(
+            ISiteContext siteSettings,
+            IUserContext user)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task SendAccountApprovalNotificationAsync(
             ISiteContext siteSettings,
             string toAddress,

--- a/src/cloudscribe.Core.Web/Components/Messaging/ISiteMessageEmailSender.cs
+++ b/src/cloudscribe.Core.Web/Components/Messaging/ISiteMessageEmailSender.cs
@@ -35,6 +35,10 @@ namespace cloudscribe.Core.Web.Components.Messaging
             ISiteContext siteSettings,
             IUserContext user);
 
+        Task NewAccountAdminNotification(
+            ISiteContext siteSettings,
+            IUserContext user);
+
         Task SendAccountApprovalNotificationAsync(
             ISiteContext siteSettings,
             string toAddress,

--- a/src/cloudscribe.Core.Web/Controllers/AccountController.cs
+++ b/src/cloudscribe.Core.Web/Controllers/AccountController.cs
@@ -578,6 +578,11 @@ namespace cloudscribe.Core.Web.Controllers.Mvc
 
                 if (result.SignInResult.Succeeded || (result.SignInResult.IsNotAllowed && result.User != null))
                 {
+                    if (! (CurrentSite.RequireApprovalBeforeLogin || CurrentSite.RequireConfirmedEmail))
+                    {
+                        await EmailSender.NewAccountAdminNotification(CurrentSite, result.User).ConfigureAwait(false);
+                    }
+
                     await CustomRegistration.HandleRegisterPostSuccess(
                         CurrentSite,
                         model,
@@ -934,8 +939,11 @@ namespace cloudscribe.Core.Web.Controllers.Mvc
                     await EmailSender.AccountPendingApprovalAdminNotification(CurrentSite, result.User).ConfigureAwait(false);
                     return RedirectToAction("PendingApproval", new { userId = result.User.Id, didSend = true });      
                 }
-                else if(!string.IsNullOrWhiteSpace(returnUrl))
-                {
+                
+                await EmailSender.NewAccountAdminNotification(CurrentSite, result.User).ConfigureAwait(false);
+
+                if(!string.IsNullOrWhiteSpace(returnUrl))
+                {                    
                     // if we have a return url we should just go ahead and redirect to login
                     this.AlertSuccess(StringLocalizer["Thank you for confirming your email."], true);
                     return RedirectToAction("Login", new { returnUrl });

--- a/src/cloudscribe.Core.Web/Controllers/AccountController.cs
+++ b/src/cloudscribe.Core.Web/Controllers/AccountController.cs
@@ -926,7 +926,7 @@ namespace cloudscribe.Core.Web.Controllers.Mvc
                 return this.RedirectToSiteRoot(CurrentSite);
             }
 
-            bool? isEmailAlreadyConfirmed = await AccountService.IsEmailConfirmedAsync(userId, code);
+            bool? isEmailAlreadyConfirmed = await AccountService.IsEmailConfirmedAsync(userId);
             
             var result = await AccountService.ConfirmEmailAsync(userId, code);
             

--- a/src/cloudscribe.Core.Web/ViewModels/Email/NewAccountEmailViewModel.cs
+++ b/src/cloudscribe.Core.Web/ViewModels/Email/NewAccountEmailViewModel.cs
@@ -1,0 +1,10 @@
+using cloudscribe.Core.Models;
+
+namespace cloudscribe.Core.Web.ViewModels.Email
+{
+    public class NewAccountEmailViewModel
+    {
+        public ISiteContext Tenant { get; set; }
+        public IUserContext User { get; set; }
+    }
+}

--- a/src/cloudscribe.Core.Web/ViewModels/SiteSettings/SecuritySettingsViewModel.cs
+++ b/src/cloudscribe.Core.Web/ViewModels/SiteSettings/SecuritySettingsViewModel.cs
@@ -35,7 +35,7 @@ namespace cloudscribe.Core.Web.ViewModels.SiteSettings
         [Display(Name = "Require Admin Account Approval")]
         public bool RequireApprovalBeforeLogin { get; set; }
 
-        [Display(Name = "Email addresses (csv) to notify of new unapproved users")]
+        [Display(Name = "Email addresses (csv) to notify of new and new unapproved users")]
         public string AccountApprovalEmailCsv { get; set; } = string.Empty;
 
         [Display(Name = "Allow Persistent Login")]

--- a/src/cloudscribe.Core.Web/ViewModels/SiteSettings/SecuritySettingsViewModel.cs
+++ b/src/cloudscribe.Core.Web/ViewModels/SiteSettings/SecuritySettingsViewModel.cs
@@ -35,7 +35,7 @@ namespace cloudscribe.Core.Web.ViewModels.SiteSettings
         [Display(Name = "Require Admin Account Approval")]
         public bool RequireApprovalBeforeLogin { get; set; }
 
-        [Display(Name = "Email addresses (csv) to notify of new and new unapproved users")]
+        [Display(Name = "Email addresses (csv) to notify of new users")]
         public string AccountApprovalEmailCsv { get; set; } = string.Empty;
 
         [Display(Name = "Allow Persistent Login")]

--- a/src/cloudscribe.Core.Web/cloudscribe.Core.Web.csproj
+++ b/src/cloudscribe.Core.Web/cloudscribe.Core.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Multi-tenant web application foundation with management for sites, users, roles, claims, and geographic data.</Description>
-    <Version>4.0.5</Version>
+    <Version>4.0.6</Version>
    
     <Authors>Joe Audette</Authors>
     <TargetFrameworks>netcoreapp3.0</TargetFrameworks>


### PR DESCRIPTION
A 'NewAccountAdminNotificationHtmlEmail' template email will be sent to the emails in 'Email addresses (csv) to notify of  new unapproved users' field in Security Settings if:

1) Account Approval is not required or Email Verification is not required
2) Account Approval is not required, but Email Verification is required, in which case we send only once, the first time a valid email verification key is verified. (Users can click the email link many times ;)